### PR TITLE
wordle: Refactor to use type-state pattern

### DIFF
--- a/games/wordle/src/lib.rs
+++ b/games/wordle/src/lib.rs
@@ -8,5 +8,8 @@ pub mod game;
 pub mod guess;
 pub mod word;
 
+pub use game::Game;
+pub use word::Word;
+
 const WORD_LENGTH: usize = 5;
 const MAX_GUESSES: usize = 6;


### PR DESCRIPTION
Existing implementation has a clunky API that is difficult to work with.
Refactor ActiveGame and GameOutcome to be Games with a marker type.

Re-export some types at the library root to make easier for library
consumers.
