### PR TITLE
wordle: track placements for whole alphabet

### DIFF
--- a/cli/src/wordle.rs
+++ b/cli/src/wordle.rs
@@ -25,6 +25,7 @@ pub fn run(args: &Args) -> std::io::Result<()> {
                 for guess in g.guesses() {
                     println!("{guess}");
                 }
+                println!("{}", g.alphabet());
                 print!("Enter guess: ");
                 std::io::stdout().flush()?;
 

--- a/games/wordle/src/alphabet.rs
+++ b/games/wordle/src/alphabet.rs
@@ -1,0 +1,62 @@
+use std::fmt::Display;
+
+use colored::Colorize as _;
+
+use crate::guess::{Guess, Placement};
+
+#[derive(Debug, Clone)]
+pub struct Alphabet([(u8, Option<Placement>); 26]);
+
+impl Alphabet {
+    #[must_use]
+    pub fn new() -> Self {
+        let mut alphabet = [(0u8, None); 26];
+
+        for (i, letter) in (b'a'..=b'z').enumerate() {
+            alphabet[i].0 = letter;
+        }
+
+        Self(alphabet)
+    }
+
+    #[must_use]
+    pub const fn letters(&self) -> &[(u8, Option<Placement>)] {
+        &self.0
+    }
+
+    pub fn report_guess(&mut self, guess: &Guess) {
+        for (letter, placement) in guess.word().as_bytes().iter().zip(guess.result().iter()) {
+            let index = (letter - b'a') as usize;
+            if let (_, Some(p)) = self.0[index] {
+                self.0[index].1 = Some(p.max(*placement));
+            } else {
+                self.0[index].1 = Some(*placement);
+            }
+        }
+    }
+}
+
+impl Default for Alphabet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Display for Alphabet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (letter, placement) in self.0 {
+            let letter = &[letter];
+            let letter = unsafe { str::from_utf8_unchecked(letter) };
+            let letter = match placement {
+                Some(Placement::Correct) => letter.bold().green(),
+                Some(Placement::Misplaced) => letter.bold().yellow(),
+                Some(Placement::Incorrect) => letter.bold().dimmed().white(),
+                None => letter.bold().white(),
+            };
+
+            write!(f, "{letter}")?;
+        }
+
+        Ok(())
+    }
+}

--- a/games/wordle/src/guess.rs
+++ b/games/wordle/src/guess.rs
@@ -3,16 +3,16 @@ use crate::word::Word;
 use colored::Colorize as _;
 
 /// An indicator of whether a letter in a guess is in the word.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Placement {
     /// The letter is not in the solution.
-    Incorrect,
+    Incorrect = 0,
 
     /// The letter is in the solution, but not in the given spot.
-    Misplaced,
+    Misplaced = 1,
 
     /// The letter is in the solution in the given spot.
-    Correct,
+    Correct = 2,
 }
 
 /// A guess that was submitted to a game.

--- a/games/wordle/src/lib.rs
+++ b/games/wordle/src/lib.rs
@@ -3,6 +3,7 @@
 //! The types exposed by this crate seek to make invalid states unrepresentable while still
 //! allowing some degree of customization of behavior.
 
+pub mod alphabet;
 pub mod dict;
 pub mod game;
 pub mod guess;


### PR DESCRIPTION
Add an `Alphabet` struct to games that keeps track of known placements
for all letters in the alphabet based on guesses made so far.
Allows for displaying letters like how the keyboard does on the wordle
site.

Paves the way for future implementation of "hard mode"
