### PR TITLE
chore: Fix clippy lint warnings

### DIFF
--- a/crates/swordle/src/game/outcome.rs
+++ b/crates/swordle/src/game/outcome.rs
@@ -20,12 +20,10 @@ impl GameOutcome {
             .is_some_and(|g| g.word() == &self.solution)
     }
 
-    #[must_use]
     pub fn solution(&self) -> &Word {
         &self.solution
     }
 
-    #[must_use]
     pub fn guesses(&self) -> &[Guess] {
         &self.guesses
     }

--- a/crates/swordle/src/game/playing.rs
+++ b/crates/swordle/src/game/playing.rs
@@ -24,7 +24,6 @@ impl PlayingGame {
     }
 
     /// Returns the guesses the player has made already.
-    #[must_use]
     pub fn guesses(&self) -> &[Guess] {
         &self.guesses
     }

--- a/crates/swordle/src/guess.rs
+++ b/crates/swordle/src/guess.rs
@@ -47,7 +47,6 @@ impl Guess {
         matches!(self, Guess::Correct(_))
     }
 
-    #[must_use]
     pub const fn word(&self) -> &Word {
         match self {
             Guess::Correct(w) | Guess::Incorrect(w, _) => w,


### PR DESCRIPTION
Fix some warnings caused by duplicate function/type `#[must_use]` markers
