### PR TITLE
ci: Deny clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,6 @@ jobs:
     - name: Build
       run: cargo build --workspace --verbose
     - name: Lint
-      run: cargo clippy --workspace
+      run: cargo clippy --workspace --verbose -- -D warnings
     - name: Run tests
       run: cargo test --workspace --verbose


### PR DESCRIPTION
Run lint/clippy with flags to deny warnings in ci workflow
