### PR TITLE
swordle: Optimize word constructor checks

### DIFF
--- a/crates/swordle/src/word/bank.rs
+++ b/crates/swordle/src/word/bank.rs
@@ -9,9 +9,7 @@ static GUESSES: LazyLock<Box<[Word]>> =
 
 /// Returns whether a given word is a valid solution/guess in the bank/dictionary.
 pub fn contains(word: Word) -> bool {
-    [&SOLUTIONS, &GUESSES]
-        .iter()
-        .any(|c| c.binary_search(&word).is_ok())
+    [&GUESSES].iter().any(|c| c.binary_search(&word).is_ok())
 }
 
 /// Returns a random word from the solutions bank.


### PR DESCRIPTION
Update `Word::new()'s` checks when ensuring the word is valid to only
binary search over the `GUESSES` constant instead of `SOLUTIONS` then
`GUESSES`. While this can be slightly slower when creating/validating a
solution word, in most cases it is actually faster since it only needs
to search over a single list of words.
